### PR TITLE
Fix MagicJobGiver on Arcane Forge

### DIFF
--- a/Source/TMagic/TMagic/HarmonyPatches.cs
+++ b/Source/TMagic/TMagic/HarmonyPatches.cs
@@ -3241,7 +3241,7 @@ namespace TorannMagic
                         if(item is Building && (item.def == TorannMagicDefOf.TableArcaneForge))
                         {
                             CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
-                            if(comp != null && comp.Mana.CurLevel < .5f)
+                            if(comp != null && comp.Mana != null && comp.Mana.CurLevel < .5f)
                             {
                                 string text = null;
                                 Action action = null;


### PR DESCRIPTION
- Fixes a bug where if a pawn did not have Mana it would give a null error and no float menu option would appear.