### PR TITLE
Add a configuration option for maxLevel for custom classes

### DIFF
--- a/Defs/CustomDefs/TM_CustomClassDef.xml
+++ b/Defs/CustomDefs/TM_CustomClassDef.xml
@@ -43,6 +43,8 @@
 			<isMage>true</isMage>							<!-- assigns mana need, validation to execute magic related tasks, and determines prerequisite trait to become this type of class -->
 			<isFighter>true</isFighter>						<!-- assigns stamina need, validation to execute might related tasks, and determines prerequisite trait to become this type of class -->
 															<!-- if both mage and fighter are true, then either precursor is valid for promotion -->
+            <!--<maxMageLevel>150</maxMageLevel>-->         <!--Overrides the default maxLevel of 150-->
+            <!--<maxFighterLevel>150</maxFighterLevel>-->         <!--Overrides the default maxLevel of 150-->
 			<isNecromancer>false</isNecromancer>			<!-- counts as a necromancer for undead upkeep -->
 			<isUndead>false</isUndead>						<!-- counts as an undead for light magic damage, assign class hediff "TM_Undead" or "TM_LichHD" for undead health benefits; -->
 															<!-- class with undead hediffs will instantly die if no necromancer is available to sustain -->

--- a/Source/TMagic/TMagic/CompAbilityUserMagic.cs
+++ b/Source/TMagic/TMagic/CompAbilityUserMagic.cs
@@ -2092,7 +2092,7 @@ namespace TorannMagic
         {
             if (!(this.Pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless) || this.Pawn.story.traits.HasTrait(TorannMagicDefOf.TM_Wayfarer)))
             {
-                if (this.MagicUserLevel < 150)
+                if (this.MagicUserLevel < (this.customClass?.maxMageLevel ?? 150))
                 {
                     this.MagicUserLevel++;
                     bool flag = !hideNotification;

--- a/Source/TMagic/TMagic/CompAbilityUserMight.cs
+++ b/Source/TMagic/TMagic/CompAbilityUserMight.cs
@@ -1320,7 +1320,7 @@ namespace TorannMagic
         {
             if (!this.Pawn.story.traits.HasTrait(TorannMagicDefOf.TM_Wanderer))
             {
-                if (this.MightUserLevel < 150)
+                if (this.MightUserLevel < (this.customClass?.maxFighterLevel ?? 150))
                 {
                     this.MightUserLevel++;
                     bool flag = !hideNotification;

--- a/Source/TMagic/TMagic/TMDefs/TM_CustomClass.cs
+++ b/Source/TMagic/TMagic/TMDefs/TM_CustomClass.cs
@@ -29,7 +29,9 @@ namespace TorannMagic.TMDefs
 
         //Class Designations
         public bool isMage = false;
+        public int maxMageLevel = 150;
         public bool isFighter = false;
+        public int maxFighterLevel = 150;
         public bool isNecromancer = false;
         public bool isUndead = false;
         public bool isAndroid = false;


### PR DESCRIPTION
Note: If the maxlevel is not specified in the custom class definition the default maxLevel from TM_CustomClass will take precedence on the default in CompAbilityUserXYZ.