### PR TITLE
Add a DefModExtension to support custom Undead hediffdef

### DIFF
--- a/Defs/HediffDefs/Hediffs_Necro.xml
+++ b/Defs/HediffDefs/Hediffs_Necro.xml
@@ -15,6 +15,11 @@
 	<maxSeverity>4.0</maxSeverity>
 	<initialSeverity>0.95</initialSeverity>
 	<isBad>false</isBad>
+    <!--<modExtensions>
+        <li Class="TorannMagic.DefModExtension_NecroStarvation">    Uncomment this to make humanlike undead recieve a hediff when no necrotic energy is available
+            <effect>RayofHope</effect>                              The hediff will be cured when a Necro or Lich comes nearby, but not by necrotic orbs.
+        </li>                                                       Not tested with severity-based hediff
+    </modExtensions>-->
 	<comps>
 	  <li>
         <compClass>TorannMagic.HediffComp_Undead</compClass>

--- a/Source/TMagic/TMagic/DefModExtension_NecroStarvation.cs
+++ b/Source/TMagic/TMagic/DefModExtension_NecroStarvation.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using RimWorld;
+using AbilityUser;
+using Verse;
+using UnityEngine;
+
+namespace TorannMagic
+{
+    class DefModExtension_NecroStarvation : DefModExtension
+    {
+        public HediffDef effect;
+        public DefModExtension_NecroStarvation() : base()
+        {
+        }
+    }
+}

--- a/Source/TMagic/TMagic/TorannMagic.csproj
+++ b/Source/TMagic/TMagic/TorannMagic.csproj
@@ -640,6 +640,7 @@
     <Compile Include="Weapon\SeerRing_Lightning.cs" />
     <Compile Include="Weapon\SeerRing_Ice.cs" />
     <Compile Include="Weapon\SeerRing_Fire.cs" />
+    <Compile Include="DefModExtension_NecroStarvation.cs" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
Add a DefModExtension to change the behaviour of undeads when no necrotic
energy is available. The undead will recieve a specific hediff instead of dying.