### PR TITLE
Fixed ShatterSentinel magic spell

### DIFF
--- a/Source/TMagic/TMagic/Verb_ShatterSentinel.cs
+++ b/Source/TMagic/TMagic/Verb_ShatterSentinel.cs
@@ -1,3 +1,4 @@
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
@@ -45,42 +46,42 @@ namespace TorannMagic
         private void ShatterSentinel(Thing sentinel, Map map)
         {
             float radius = 4f;
-            Vector3 center = sentinel.DrawPos;
+            Vector3 center = sentinel.DrawPos;            
 
-            IEnumerable<IntVec3> damageRing = GenRadial.RadialCellsAround(sentinel.Position, radius, true);
-            IEnumerable<IntVec3> outsideRing = GenRadial.RadialCellsAround(sentinel.Position, radius, false).Except(GenRadial.RadialCellsAround(sentinel.Position, radius - 1, true));
-            foreach (var location in damageRing)
+            List<IntVec3> damageRing = GenRadial.RadialCellsAround(sentinel.Position, radius, true).ToList();
+            List<IntVec3> outsideRing = GenRadial.RadialCellsAround(sentinel.Position, radius, false).Except(GenRadial.RadialCellsAround(sentinel.Position, radius - 1, true)).ToList();
+            for (int i = 0; i < damageRing.Count; i++)
             {
-                List<Thing> allThings = location.GetThingList(map);
+                List<Thing> allThings = damageRing[i].GetThingList(map);
                 for (int j = 0; j < allThings.Count; j++)
                 {
-                    var thing = allThings[j];
-                    if (thing is Pawn)
+                    if (allThings[j] is Pawn)
                     {
-                        Pawn p = thing as Pawn;
+                        Pawn p = allThings[j] as Pawn;
                         TM_Action.DamageEntities(p, p.health.hediffSet.GetRandomNotMissingPart(DamageDefOf.Blunt, BodyPartHeight.Undefined, BodyPartDepth.Outside, null), Rand.Range(14, 22), DamageDefOf.Blunt, this.CasterPawn);
                     }
-                    else if (thing is Building)
+                    else if (allThings[j] is Building)
                     {
-                        TM_Action.DamageEntities(thing, null, Rand.Range(56, 88), DamageDefOf.Blunt, this.CasterPawn);
+                        TM_Action.DamageEntities(allThings[j], null, Rand.Range(56, 88), DamageDefOf.Blunt, this.CasterPawn);
                     }
                     else
                     {
                         if (Rand.Chance(.1f))
                         {
-                            GenPlace.TryPlaceThing(ThingMaker.MakeThing(ThingDefOf.Filth_RubbleRock), location, map, ThingPlaceMode.Near);
+                            GenPlace.TryPlaceThing(ThingMaker.MakeThing(ThingDefOf.Filth_RubbleRock), damageRing[i], map, ThingPlaceMode.Near);
                         }
                     }
                 }
             }
-            foreach (var outerLoc in outsideRing)
+            for (int i = 0; i < outsideRing.Count; i++)
             {
-                if (outerLoc.IsValid && outerLoc.InBounds(map))
+                IntVec3 intVec = outsideRing[i];
+                if (intVec.IsValid && intVec.InBounds(map))
                 {
-                    Vector3 moteDirection = TM_Calc.GetVector(sentinel.DrawPos.ToIntVec3(), outerLoc);
+                    Vector3 moteDirection = TM_Calc.GetVector(sentinel.DrawPos.ToIntVec3(), intVec);
                     TM_MoteMaker.ThrowGenericMote(ThingDef.Named("Mote_Rubble"), sentinel.DrawPos, map, Rand.Range(.3f, .6f), .2f, .02f, .05f, Rand.Range(-100, 100), Rand.Range(8f, 13f), (Quaternion.AngleAxis(90, Vector3.up) * moteDirection).ToAngleFlat(), 0);
                     TM_MoteMaker.ThrowGenericMote(ThingDefOf.Mote_Smoke, sentinel.DrawPos, map, Rand.Range(.9f, 1.2f), .3f, .02f, Rand.Range(.25f, .4f), Rand.Range(-100, 100), Rand.Range(5f, 8f), (Quaternion.AngleAxis(90, Vector3.up) * moteDirection).ToAngleFlat(), 0);
-                    GenExplosion.DoExplosion(outerLoc, map, .4f, DamageDefOf.Blunt, this.CasterPawn, 0, 0, SoundDefOf.Pawn_Melee_Punch_HitBuilding, null, null, null, ThingDefOf.Filth_RubbleRock, .4f, 1, false, null, 0f, 1, 0, false);
+                    GenExplosion.DoExplosion(intVec, map, .4f, DamageDefOf.Blunt, this.CasterPawn, 0, 0, SoundDefOf.Pawn_Melee_Punch_HitBuilding, null, null, null, ThingDefOf.Filth_RubbleRock, .4f, 1, false, null, 0f, 1, 0, false);
                     //MoteMaker.ThrowSmoke(intVec.ToVector3Shifted(), base.Map, Rand.Range(.6f, 1f));
                 }
             }


### PR DESCRIPTION
Treating two bugs

1. A case where the the sentinel is destroyed inside the loop but isn't deleted from the summoned sentinels list
2. Removing a sentinel from the list while still iterating it will cause the list to shrink while still having the same index 'i' which causes you to miss the next sentinel.


These two bugs are very common and spread throughout this mod, I'm adding a fix here only as a FYI